### PR TITLE
クウォータ上限対策

### DIFF
--- a/back/app/controllers/movies_controller.rb
+++ b/back/app/controllers/movies_controller.rb
@@ -2,26 +2,28 @@ require 'httparty'
 
 class MoviesController < ApplicationController
   # before_action :set_movie, only: %i[show]
-  def index
-    if params[:looking_for]
-      @movies = fetch_movies("/search/movie", query: params[:looking_for])
+  def index ;
+    # if params[:looking_for]
+    #   @movies = fetch_movies("/search/movie", query: params[:looking_for])
 
-    else
-      @movies = fetch_movies("/movie/popular")
-    end
-    Rails.logger.debug(@movies.inspect)
-    render 'index'
+    # else
+    #   @movies = fetch_movies("/movie/popular")
+    # end
+    # Rails.logger.debug(@movies.inspect)
+    # render 'index'
   end
 
   def show
     movie_data = MovieFetcher.fetch_movie_details(params[:id])
-    Rails.logger.debug("ここに注目！！！！#{movie_data['title']}")
     Rails.logger.debug(movie_data)
-
     @video_id = fetch_youtube_video(movie_data['title'])
     @keywords = get_keywords(movie_data['id'])
-    @movie = MovieSaverService.save_movie(movie_data, @video_id,@keywords)
     
+    unless @video_id.nil?
+      @movie = MovieSaverService.save_movie(movie_data, @video_id,@keywords)
+    else
+      @movie = movie_data
+    end
   end
 
   def random
@@ -29,7 +31,8 @@ class MoviesController < ApplicationController
     @video_id = fetch_youtube_video(@movie_data['title'])
     Rails.logger.debug(@movie_data)
     @keywords = get_keywords(@movie_data[:id])
-    Rails.logger.debug("注目して！！！！#{@movie_data[:id]}")
+
+    @movie = Movie.all.sample if @video_id.nil?
     @movie = MovieSaverService.save_movie(@movie_data, @video_id, @keywords)
   end
 

--- a/back/app/models/movie.rb
+++ b/back/app/models/movie.rb
@@ -19,7 +19,7 @@ class Movie < ApplicationRecord
       status: movie_data[:status],
       release_date: movie_data[:release_date],
       genres: movie_data[:genres],
-      # youtube_trailer_id: video_id["id"]["videoId"],
+      youtube_trailer_id: video_id["id"]["videoId"],
       keywords: keywords
     )
     save!

--- a/back/app/views/movies/index.html.erb
+++ b/back/app/views/movies/index.html.erb
@@ -1,20 +1,3 @@
-<%= button_to 'Delete', destroy_user_session_path, :method => :delete %>
 <div class="movies-container">
-  <% if @movies.present? %>
-    <% @movies['results'].each do |movie| %>
-      <div class="movie-data">
-        <p><%= movie['title'] %></p>
-        <p><%= movie['overview'] %></p>
-        <%= link_to movie_path(movie['id']) do %>
-          <% if movie['poster_path'] %>
-            <p><%= image_tag 'https://image.tmdb.org/t/p/w200' + movie['poster_path'], class: "card-img" %></p>
-          <% end %>
-        <% end %>
-        <p><%= link_to "ランダム", random_movies_path(movie['id']) %></p>
-        <p><%= link_to "詳細へ", movie_path(movie['id']), data: { movie: movie.to_json } %></p>
-      </div>
-    <% end %>
-  <% else %>
-    <p>No movies found.</p>
-  <% end %>
+  <p><%= link_to "ランダム", random_movies_path %></p>
 </div>

--- a/back/app/views/movies/random.html.erb
+++ b/back/app/views/movies/random.html.erb
@@ -5,9 +5,6 @@
 <% end %>
 <div id='player'></div>
 <p><%= @movie.overview %></p>
-<% @keywords.each do |k| %>
-  <p><%= k['name'] %></p>
-<% end %>
 <iframe id="player" width="640" height="360" 
   src="https://www.youtube.com/embed/<%= @movie.youtube_trailer_id %>
   ?autoplay=1&mute=1&loop=1&playlist=<%= @movie.youtube_trailer_id %>&rel=0" 

--- a/back/app/views/movies/show.html.erb
+++ b/back/app/views/movies/show.html.erb
@@ -1,19 +1,15 @@
-<% if @movie.title %>
 <h2><%= @movie.title %></h2>
 <% if @movie.postpath %>
   <p><%= image_tag 'https://image.tmdb.org/t/p/w200' + @movie.postpath, class: "card-img" %></p>
-<% end %>
-<div id='player'></div>
+<% end %><div id='player'></div>
 <p><%= @movie.overview %></p>
-<% @keywords.each do |k| %>
-  <p><%= k['name'] %></p>
-<% end %>
-<iframe id="player" width="640" height="360" 
-  src="https://www.youtube.com/embed/<%= @movie.youtube_trailer_id %>
-  ?autoplay=1&mute=1&loop=1&playlist=<%= @movie.youtube_trailer_id %>&rel=0" 
-  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" 
-  allowfullscreen>
-</iframe>
+<% if @video_id.nil? %>
+  <p>予告がございません</p>
 <% else %>
-<p>映画情報を取得できませんでした。</p>
+  <iframe id="player" width="640" height="360" 
+    src="https://www.youtube.com/embed/<%= @movie.youtube_trailer_id %>
+    ?autoplay=1&mute=1&loop=1&playlist=<%= @movie.youtube_trailer_id %>&rel=0" 
+    frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" 
+    allowfullscreen>
+</iframe>
 <% end %>


### PR DESCRIPTION
Youtube APIのクウォータ上限に達してしまった場合の
処理を追加しました。
主に追加したのは2点。
- ランダムで動画を選ぶ場合に達した場合は
動画を取得する場所をtmdb APIからアプリのDBに変更するようにしました。
- 詳細画面を開くときに上限に達してしまった場合は
予告編が流れない旨を伝える分を代わりに追加しました。（ここの文章は後に変える）
また、詳細画面を開いたタイミングでDBにない場合は保存される仕様に
なっていてyoutube idがnilの状態で保存されるのを防ぐために
youtube idがnilのときは保存しない仕様にしてあります。