### PR TITLE
映画の検索機能の追加

### DIFF
--- a/back/app/controllers/movies_controller.rb
+++ b/back/app/controllers/movies_controller.rb
@@ -16,7 +16,7 @@ class MoviesController < ApplicationController
   def show
     movie_data = MovieFetcher.fetch_movie_details(params[:id])
     Rails.logger.debug(movie_data)
-    @video_id = fetch_youtube_video(movie_data['title'])
+    @video_id = fetch_youtube_video(movie_data['original_title'])
     @keywords = get_keywords(movie_data['id'])
     
     unless @video_id.nil?
@@ -28,7 +28,8 @@ class MoviesController < ApplicationController
 
   def search
     if params[:query].present?
-      @movies = Tmdb::Search.movie(params[:query]).results
+      search = fetch_tmdb_search(params[:query])
+      @movies = search["results"]
     else
       movie = []
     end
@@ -36,7 +37,7 @@ class MoviesController < ApplicationController
 
   def random
     @movie_data = TmdbService.get_random_movie
-    @video_id = fetch_youtube_video(@movie_data[:title])
+    @video_id = fetch_youtube_video(@movie_data[:original_title])
     @keywords = get_keywords(@movie_data[:id])
 
     Rails.logger.debug("ここを見てくれ！#{@video_id}")
@@ -74,5 +75,20 @@ class MoviesController < ApplicationController
   def fetch_youtube_video(title)
     youtube_search_query = "#{title} 映画 予告"
     YoutubeService.search_videos(youtube_search_query)
+  end
+    BASE_URL = "https://api.themoviedb.org/3"
+    API_KEY = ENV['TMDB_API']
+  def fetch_tmdb_search(query)
+
+    
+    language = "ja"
+    base_url = "https://api.themoviedb.org/3"
+    response = HTTParty.get("#{BASE_URL}/search/movie", query: {
+      api_key: API_KEY,
+      language: 'ja',
+      query: query,
+    })
+
+    JSON.parse(response.body)
   end
 end

--- a/back/app/models/movie.rb
+++ b/back/app/models/movie.rb
@@ -11,15 +11,15 @@ class Movie < ApplicationRecord
 
   def save_with_data(movie_data, video_id, keywords)
     self.assign_attributes(
-      title: movie_data[:title],
+      original_title: movie_data[:original_title],
       overview: movie_data[:overview],
-      postpath: movie_data[:postpath],
+      poster_path: movie_data[:poster_path],
       runtime: movie_data[:runtime],
-      language: movie_data[:language],
+      original_language: movie_data[:original_language],
       status: movie_data[:status],
       release_date: movie_data[:release_date],
       genres: movie_data[:genres],
-      youtube_trailer_id: video_id["id"]["videoId"],
+      youtube_trailer_id: video_id.dig("id", "videoId"),
       keywords: keywords
     )
     save!

--- a/back/app/services/movie_saver_service.rb
+++ b/back/app/services/movie_saver_service.rb
@@ -2,7 +2,7 @@ class MovieSaverService
   def self.save_movie(movie_data, video_id, keywords)
     Rails.logger.debug("Received movie_data: #{movie_data.inspect}")
     movie_data = movie_data.transform_keys(&:to_sym)
-    movie = Movie.find_or_initialize_by(title: movie_data[:title])
+    movie = Movie.find_or_initialize_by(original_title: movie_data[:original_title])
 
     if movie.new_record?
       if movie.save_with_data(movie_data, video_id, keywords)

--- a/back/app/services/tmdb_service.rb
+++ b/back/app/services/tmdb_service.rb
@@ -47,11 +47,11 @@ class TmdbService
       movie = JSON.parse(response.body)
       movie_data = {
         id: movie['id'],
-        title: movie['title'],
+        original_title: movie['original_title'],
         overview: movie['overview'],
-        postpath: movie['poster_path'],
+        poster_path: movie['poster_path'],
         runtime: movie['runtime'],
-        language: movie['original_language'],
+        original_language: movie['original_language'],
         status: movie['status'],
         release_date: movie['release_date'],
         genres: movie['genres'],

--- a/back/app/views/movies/random.html.erb
+++ b/back/app/views/movies/random.html.erb
@@ -1,7 +1,7 @@
-<% if @movie.title %>
-<h2><%= @movie.title %></h2>
-<% if @movie.postpath %>
-    <p><%= image_tag 'https://image.tmdb.org/t/p/w200' + @movie.postpath, class: "card-img" %></p>
+<% if @movie.original_title %>
+<h2><%= @movie.original_title %></h2>
+<% if @movie.poster_path %>
+    <p><%= image_tag 'https://image.tmdb.org/t/p/w200' + @movie.poster_path, class: "card-img" %></p>
 <% end %>
 <div id='player'></div>
 <p><%= @movie.overview %></p>

--- a/back/app/views/movies/search.html.erb
+++ b/back/app/views/movies/search.html.erb
@@ -7,9 +7,11 @@
 <% end %>
 
 <% unless @movies.nil? %>
-  <ul>
+<ul>
     <% @movies.each do |movie| %>
-      <li><%= movie.title %> (<%= movie.release_date %>)</li>
+        <%= link_to movie_path(movie["id"]) do %>
+          <%= image_tag("https://image.tmdb.org/t/p/w200#{movie['poster_path']}", alt: movie['original_title']) %>
+        <% end %>
     <% end %>
   </ul>
 <% else %>

--- a/back/app/views/movies/show.html.erb
+++ b/back/app/views/movies/show.html.erb
@@ -1,8 +1,8 @@
-<h2><%= @movie.title %></h2>
-<% if @movie.postpath %>
-  <p><%= image_tag 'https://image.tmdb.org/t/p/w200' + @movie.postpath, class: "card-img" %></p>
+<h2><%= @movie["original_title"] %></h2>
+<% if @movie["poster_path"] %>
+  <p><%= image_tag 'https://image.tmdb.org/t/p/w200' + @movie["poster_path"], class: "card-img" %></p>
 <% end %><div id='player'></div>
-<p><%= @movie.overview %></p>
+<p><%= @movie["overview"] %></p>
 <% if @video_id.nil? %>
   <p>予告がございません</p>
 <% else %>

--- a/back/db/migrate/20240529220109_rename_old_column_to_new_column_in_movies.rb
+++ b/back/db/migrate/20240529220109_rename_old_column_to_new_column_in_movies.rb
@@ -1,0 +1,7 @@
+class RenameOldColumnToNewColumnInMovies < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :movies, :postpath, :poster_path
+    rename_column :movies, :language, :original_language
+    rename_column :movies, :title, :original_title
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_28_072734) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_29_220109) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,11 +33,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_072734) do
   end
 
   create_table "movies", force: :cascade do |t|
-    t.string "title"
+    t.string "original_title"
     t.text "overview"
-    t.string "postpath"
+    t.string "poster_path"
     t.integer "runtime"
-    t.string "language"
+    t.string "original_language"
     t.string "status"
     t.date "release_date"
     t.json "genres"

--- a/back/test/fixtures/movies.yml
+++ b/back/test/fixtures/movies.yml
@@ -1,21 +1,21 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  title: MyString
+  original_title: MyString
   overview: MyText
-  postpath: MyString
+  poster_path: MyString
   runtime: 1
-  language: MyString
+  original_language: MyString
   status: MyString
   release_date: 2024-05-24
   genres: 
 
 two:
-  title: MyString
+  original_title: MyString
   overview: MyText
-  postpath: MyString
+  poster_path: MyString
   runtime: 1
-  language: MyString
+  original_language: MyString
   status: MyString
   release_date: 2024-05-24
   genres: 


### PR DESCRIPTION
TMDB APIから映画の検索をできる機能を追加しました。

追加する過程で不具合も見つけたので以下を修正しました。
- TMDB APIのレスポンスでたまに映画の題名のkeyをtiltleではなくnameで
登録しているものが出てきて、データを読み取れないことがあったので
多く対応するためにMoviesテーブルのカラム名を
title -> original_title
に変えてこれのついでに似たような不具合がある場合を考慮して
TMDB APIがレスポンスで返してくれてるkeyに名前を合わせることにしました。
なので
postpath -> poster_path
language -> original_languageに変更してあります。