### PR TITLE
collectionテーブルの仕様変更

### DIFF
--- a/back/app/models/collection.rb
+++ b/back/app/models/collection.rb
@@ -5,7 +5,7 @@ class Collection < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :bookmarked_users, through: :bookmarks, source: :user
 
-  validates :title, presence: true, uniqueness: true, length: { maximum: 15 }
+  validates :title, presence: true, length: { maximum: 15 }
   validates :description, length: { maximum: 130 }
   validate :must_one_movie
 

--- a/back/db/migrate/20240718103637_remove_unique_constraint_from_collections_title.rb
+++ b/back/db/migrate/20240718103637_remove_unique_constraint_from_collections_title.rb
@@ -1,0 +1,17 @@
+class RemoveUniqueConstraintFromCollectionsTitle < ActiveRecord::Migration[7.0]
+  def up
+    # 既存のユニークインデックスを削除
+    remove_index :collections, name: "index_collections_on_title"
+    
+    # 新しい非ユニークインデックスを追加
+    add_index :collections, :title
+  end
+
+  def down
+    # 非ユニークインデックスを削除
+    remove_index :collections, :title
+    
+    # ユニークインデックスを再追加
+    add_index :collections, :title, unique: true
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_04_044336) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_18_103637) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,7 +40,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_044336) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["title"], name: "index_collections_on_title", unique: true
+    t.index ["title"], name: "index_collections_on_title"
     t.index ["user_id"], name: "index_collections_on_user_id"
   end
 


### PR DESCRIPTION
collectionテーブルのタイトル名のunique制約を破棄しました。
これはユーザーが今日のランダムで選ばれた映画をメモ的に
保存したい声があり、一意性があると気軽にメモとして
機能しない可能性を考慮したためです。